### PR TITLE
Add encodings.dev Base64 vs Base64 URL guide to Websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ A curated list of awesome libraries and resources about JSON Web Token (JWT), a 
 - [jwt.io](https://jwt.io/) - Reference website crafted by Auth0 (Okta).
 - [IANA JSON Web Token Claims Registry](https://www.iana.org/assignments/jwt/jwt.xhtml) - Registry listing all registered claims used in JWT.
 - [JWT & JWE Debugger](https://www.authgear.com/tools/jwt-jwe-debugger) - In-browser Open-Source JWT/JWE debugger, with examples, encryption and decryption.
+- [Base64 vs Base64 URL guide (encodings.dev)](https://encodings.dev/base64-vs-base64url) - Reference explaining the Base64 URL variant used in JWT segments, with a live in-browser encoder/decoder for inspecting tokens.
 
 ## Security Testing Tools
 


### PR DESCRIPTION
Adds [encodings.dev/base64-vs-base64url](https://encodings.dev/base64-vs-base64url)
to the **Resources → Websites** section.

## Why this fits

The page is a reference covering the Base64 URL variant that JWTs use
for all three segments (header, payload, signature) — exactly the
encoding people need to understand when working with JWTs but is
typically buried in RFC 4648 §5.

It pairs the explanation with a live in-browser encoder/decoder so
developers debugging a token can paste a segment and see the decoded
contents without sending it to a server.

Placed next to the existing **JWT & JWE Debugger** entry since the
intent is similar (in-browser JWT-related tooling).

## Compliance

- [x] Single-line addition, format matches surrounding entries
- [x] Description ends with a period
- [x] Link works (HTTP 200, valid TLS)
- [x] No GeoCities-era hosting; site is Cloudflare Pages, no tracking, no ads